### PR TITLE
Fix installation guide page link

### DIFF
--- a/articles/getting_started.md
+++ b/articles/getting_started.md
@@ -71,7 +71,7 @@ Here is what Langohr *does not* try to be:
 
 ## Installing RabbitMQ
 
-The RabbitMQ site has a good [installation guide](http://www.rabbitmq.com/install.html) that addresses many operating systems.
+The RabbitMQ site has a good [installation guide](https://www.rabbitmq.com/docs/download) that addresses many operating systems.
 
 ### MacOS
 


### PR DESCRIPTION
Then link is broken, receiving a 404. The Installation guide is currently on the docs/download page.